### PR TITLE
Fix: 修复文本分享消息抓取后保存内容为空的问题

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -224,6 +224,7 @@ export async function packHTMLAssets(fakeid: string, html: string, title: string
   const ipWordingMatchResult = html.match(/window\.ip_wording = (?<data>{\s+countryName: '[^']+',[^}]+})/s);
   if (ipWrp && ipWording && ipWordingMatchResult && ipWordingMatchResult.groups && ipWordingMatchResult.groups.data) {
     const json = ipWordingMatchResult.groups.data;
+    // eslint-disable-next-line no-eval
     eval('window.ip_wording = ' + json);
     const ipWordingDisplay = getIpWoridng((window as any).ip_wording);
     if (ipWordingDisplay !== '') {
@@ -247,6 +248,60 @@ export async function packHTMLAssets(fakeid: string, html: string, title: string
   const titleModifiedMatchResult = html.match(/window\.isTitleModified = "(?<data>\d*)" \* 1;/);
   if (titleModifiedMatchResult && titleModifiedMatchResult.groups && titleModifiedMatchResult.groups.data) {
     __setTitleModify(titleModifiedMatchResult.groups.data === '1');
+  }
+
+  // 文本分享消息
+  const $js_text_desc = $jsArticleContent.querySelector('#js_text_desc') as HTMLElement | null;
+  if ($js_text_desc) {
+    // 文本分享样式
+    bodyCls += ' page_share_text';
+
+    // 顶部作者栏
+    const qmtplTextMatchResult = html.match(/(?<code>window\.__QMTPL_SSR_DATA__\s*=\s*\{.+?};)/s);
+    if (qmtplTextMatchResult && qmtplTextMatchResult.groups && qmtplTextMatchResult.groups.code) {
+      const code = qmtplTextMatchResult.groups.code;
+      // eslint-disable-next-line no-eval
+      eval(code);
+      const data = (window as any).__QMTPL_SSR_DATA__;
+      if (data && typeof data.title === 'string' && !$js_text_desc.innerHTML.trim()) {
+        let text = data.title as string;
+        text = text.replace(/\r/g, '').replace(/\n/g, '<br>');
+        $js_text_desc.innerHTML = text;
+      }
+      $jsArticleContent.querySelector('#js_top_profile')?.classList.remove('profile_area_hide');
+    }
+
+    // 正文内容
+    if (!$js_text_desc.innerHTML.trim()) {
+      const textContentMatch = html.match(
+        /var\s+TextContentNoEncode\s*=\s*window\.a_value_which_never_exists\s*\|\|\s*(?<value>'[^']*')/s
+      );
+      const contentMatch = html.match(
+        /var\s+ContentNoEncode\s*=\s*window\.a_value_which_never_exists\s*\|\|\s*(?<value>'[^']*')/s
+      );
+
+      let desc: string | null = null;
+      const assignFromMatch = (match: RegExpMatchArray | null, key: string) => {
+        if (match && match.groups && match.groups.value) {
+          const code = `window.${key} = ${match.groups.value}`;
+          // eslint-disable-next-line no-eval
+          eval(code);
+          // @ts-ignore
+          return (window as any)[key] as string;
+        }
+        return null;
+      };
+
+      desc = assignFromMatch(textContentMatch, '__WX_TEXT_NO_ENCODE__');
+      if (!desc) {
+        desc = assignFromMatch(contentMatch, '__WX_CONTENT_NO_ENCODE__');
+      }
+
+      if (desc) {
+        desc = desc.replace(/\r/g, '').replace(/\n/g, '<br>');
+        $js_text_desc.innerHTML = desc;
+      }
+    }
   }
 
   // 文章引用


### PR DESCRIPTION
修复了文本分享消息保存后无内容的问题。主要是因为文本分享消息标题内容即包含文章内容，将标题内容保存入js_text_desc后继续渲染即可。
before
<img width="637" height="333" alt="image" src="https://github.com/user-attachments/assets/9fb6d441-e99a-4741-8434-7b13a61c3cfb" />
after
<img width="1122" height="608" alt="100edf040a5496a5ee83a77585e58fee" src="https://github.com/user-attachments/assets/c0bfec6e-dc96-4b7f-a6c0-1dd66d577a97" />

