### PR TITLE
支持禁止搜索的公众号文章的抓取

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,68 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "调试 Nuxt 服务端 + Chrome 客户端（推荐）",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [
+        "debug"
+      ],
+      "port": 9229,
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "console": "integratedTerminal",
+      "restart": true,
+      "autoAttachChildProcesses": true,
+      "serverReadyAction": {
+        "pattern": "Local:.*http://localhost:([0-9]+)",
+        "uriFormat": "http://localhost:%s",
+        "action": "debugWithChrome"
+      },
+      "sourceMapPathOverrides": {
+        "webpack:///./*": "${workspaceFolder}/*",
+        "/./*": "${workspaceFolder}/*"
+      },
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "附加到 Nuxt 服务端（需先运行 yarn debug）",
+      "port": 9229,
+      "restart": true,
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "continueOnAttach": true,
+      "sourceMapPathOverrides": {
+        "webpack:///./*": "${workspaceFolder}/*",
+        "/./*": "${workspaceFolder}/*"
+      },
+      "resolveSourceMapLocations": [
+        "${workspaceFolder}/**",
+        "!**/node_modules/**"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/.nuxt/**/*.js",
+        "${workspaceFolder}/.output/**/*.js"
+      ]
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "调试 Chrome 客户端",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}",
+      "sourceMapPathOverrides": {
+        "webpack:///./*": "${webRoot}/*",
+        "webpack:///src/*": "${webRoot}/*"
+      }
+    }
+  ]
+}

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -1,18 +1,66 @@
+import { useLocalStorage } from '@vueuse/core';
+import { ACCOUNT_LIST_PAGE_SIZE, ARTICLE_LIST_PAGE_SIZE } from '~/config';
+import { updateAPICache } from '~/store/v2/api';
+import { updateArticleCache } from '~/store/v2/article';
+import { markAccountHidden, markAccountVisible, markCompleted, updateLastUpdateTime, type Info } from '~/store/v2/info';
+import type { CommentResponse } from '~/types/comment';
+import type { ParsedCredential } from '~/types/credential';
 import type {
   AccountInfo,
   AppMsgEx,
   AppMsgPublishResponse,
   PublishInfo,
+  PublishListItem,
   PublishPage,
   SearchBizResponse,
 } from '~/types/types';
-import { ACCOUNT_LIST_PAGE_SIZE, ARTICLE_LIST_PAGE_SIZE } from '~/config';
-import { updateAPICache } from '~/store/v2/api';
-import { updateArticleCache } from '~/store/v2/article';
-import type { CommentResponse } from '~/types/comment';
-import { type Info, updateLastUpdateTime } from '~/store/v2/info';
 
 const loginAccount = useLoginAccount();
+const credentials = useLocalStorage<ParsedCredential[]>('auto-detect-credentials:credentials', []);
+// 记录 profile_ext 分页时的 next_offset，避免重复
+const profileExtNextOffset = new Map<string, number>();
+// 记录 profile_ext 已累积条数
+const profileExtLoadedCount = new Map<string, number>();
+
+interface ProfileExtResponse {
+  base_resp?: {
+    ret: number;
+    err_msg?: string;
+  };
+  ret?: number;
+  errmsg?: string;
+  general_msg_list?: string | ProfileExtList;
+  next_offset?: number;
+  can_msg_continue?: number;
+  msg_count?: number;
+}
+
+interface ProfileExtList {
+  list: ProfileExtItem[];
+  msg_count?: number;
+}
+
+interface ProfileExtItem {
+  comm_msg_info?: {
+    id?: number;
+    datetime?: number;
+    content?: string;
+  };
+  app_msg_ext_info?: ProfileExtSubItem;
+}
+
+interface ProfileExtSubItem {
+  title?: string;
+  digest?: string;
+  content_url?: string;
+  source_url?: string;
+  cover?: string;
+  is_multi?: number;
+  multi_app_msg_item_list?: ProfileExtSubItem[];
+  author?: string;
+  copyright_stat?: number;
+  copyright_type?: number;
+}
 
 /**
  * 获取文章列表
@@ -21,6 +69,31 @@ const loginAccount = useLoginAccount();
  * @param keyword
  */
 export async function getArticleList(account: Info, begin = 0, keyword = ''): Promise<[AppMsgEx[], boolean, number]> {
+  // 如果公众号禁止搜索
+  if (account.hidden) {
+    const [articles, isCompleted, total] = await getArticleListViaCredential(account, begin);
+
+    await updateAPICache({
+      name: 'appmsgpublish',
+      account: loginAccount.value?.nickname,
+      call_time: new Date().getTime(),
+      is_normal: true,
+      payload: {
+        id: account.fakeid,
+        begin: begin,
+        size: ARTICLE_LIST_PAGE_SIZE,
+        keyword: keyword,
+        hidden: true,
+      },
+    });
+
+    if (begin === 0) {
+      await updateLastUpdateTime(account.fakeid);
+    }
+
+    return [articles, isCompleted, total];
+  }
+
   const resp = await $fetch<AppMsgPublishResponse>('/api/web/mp/appmsgpublish', {
     method: 'GET',
     query: {
@@ -47,8 +120,15 @@ export async function getArticleList(account: Info, begin = 0, keyword = ''): Pr
   });
 
   if (resp.base_resp.ret === 0) {
+    // 正常获取到文章列表
     const publish_page: PublishPage = JSON.parse(resp.publish_page);
     const publish_list = publish_page.publish_list.filter(item => !!item.publish_info);
+    // 标记为可搜索
+    if (begin === 0) {
+      // 首次正常拉取即认为账号可被搜索，写回 info
+      await markAccountVisible(account.fakeid);
+      account.hidden = false;
+    }
 
     // 返回的文章数量为0就表示已加载完毕
     const isCompleted = publish_list.length === 0;
@@ -56,7 +136,7 @@ export async function getArticleList(account: Info, begin = 0, keyword = ''): Pr
     // 更新缓存，注意搜索的结果不能写入缓存
     if (!keyword) {
       try {
-        await updateArticleCache(account, publish_page);
+        await updateArticleCache({ ...account, hidden: false }, publish_page);
       } catch (e) {
         console.warn('缓存失败');
         console.error(e);
@@ -73,11 +153,252 @@ export async function getArticleList(account: Info, begin = 0, keyword = ''): Pr
     });
     return [articles, isCompleted, publish_page.total_count];
   } else if (resp.base_resp.ret === 200003) {
+    // 微信公众号登录信息已经失效
     loginAccount.value = null;
     throw new Error('session expired');
+  } else if (resp.base_resp.ret === 200002) {
+    // 公众号已禁止通过名称搜索到本账号，抛出异常等待处理
+    await markAccountHidden(account.fakeid);
+    throw new Error('公众号已设置禁止搜索，改为带登录信息方式加载公众号列表');
   } else {
+    // 其他未知错误
     throw new Error(`${resp.base_resp.ret}:${resp.base_resp.err_msg}`);
   }
+}
+
+/**
+ * 带登录信息的方式加载文章列表
+ * @param account
+ * @param begin
+ * @returns
+ */
+async function getArticleListViaCredential(account: Info, begin = 0): Promise<[AppMsgEx[], boolean, number]> {
+  const credential = credentials.value.find(item => item.biz === account.fakeid && item.valid);
+  if (!credential) {
+    throw new Error('目标公众号的 Credential 未设置');
+  }
+
+  // 首次加载重置计数
+  if (begin === 0) {
+    profileExtLoadedCount.set(account.fakeid, 0);
+    profileExtNextOffset.delete(account.fakeid);
+  }
+
+  const offsetParam = begin === 0 ? 0 : (profileExtNextOffset.get(account.fakeid) ?? begin);
+
+  const resp = await $fetch<ProfileExtResponse>('/api/web/mp/profile_ext', {
+    method: 'GET',
+    query: {
+      action: 'getmsg',
+      f: 'json',
+      is_ok: 1,
+      __biz: credential.biz,
+      pass_ticket: credential.pass_ticket,
+      key: credential.key,
+      uin: credential.uin,
+      offset: offsetParam,
+      count: 10,
+    },
+    retry: 0,
+  });
+
+  ensureProfileExtSuccess(resp);
+
+  const listJson = parseGeneralMsgList(resp.general_msg_list);
+  const list: ProfileExtItem[] = listJson?.list || [];
+
+  const articles: AppMsgEx[] = [];
+  const publish_list: PublishListItem[] = [];
+
+  for (const msg of list) {
+    const itemArticles: AppMsgEx[] = [];
+    const createTime = msg.comm_msg_info?.datetime || 0;
+    const msgId = msg.comm_msg_info?.id || Date.now();
+    const ext = msg.app_msg_ext_info;
+    if (ext) {
+      const mainArticle = buildArticleFromProfileExt(ext, msgId, 1, createTime, account);
+      itemArticles.push(mainArticle);
+      articles.push(mainArticle);
+
+      if (ext.multi_app_msg_item_list && ext.multi_app_msg_item_list.length > 0) {
+        ext.multi_app_msg_item_list.forEach((sub, idx) => {
+          const article = buildArticleFromProfileExt(sub, msgId, idx + 2, createTime, account);
+          itemArticles.push(article);
+          articles.push(article);
+        });
+      }
+    } else {
+      // 无 app_msg_ext_info（如纯文本消息）也占位，确保分页步长与 offset 对齐
+      const stub = buildStubArticle(msg, msgId, createTime);
+      itemArticles.push(stub);
+      articles.push(stub);
+    }
+
+    publish_list.push({
+      publish_type: 1,
+      publish_info: JSON.stringify({
+        appmsgex: itemArticles,
+      } as Partial<PublishInfo>),
+    });
+  }
+
+  const loadedCount = profileExtLoadedCount.get(account.fakeid) ?? 0;
+  const totalCount = loadedCount + publish_list.length;
+
+  const publish_page: PublishPage = {
+    featured_count: 0,
+    masssend_count: publish_list.length,
+    publish_count: publish_list.length,
+    publish_list,
+    total_count: totalCount,
+  };
+
+  if (articles.length > 0) {
+    try {
+      await updateArticleCache(account, publish_page);
+    } catch (e) {
+      console.warn('缓存隐藏账号文章失败');
+      console.error(e);
+    }
+  }
+
+  const isCompleted = (resp.can_msg_continue ?? 0) === 0 || list.length === 0;
+
+  // 记录下一次 offset，优先用接口返回，否则累加
+  const nextOffset = resp.next_offset ?? offsetParam + publish_list.length;
+  profileExtNextOffset.set(account.fakeid, nextOffset);
+  profileExtLoadedCount.set(account.fakeid, totalCount);
+  if (isCompleted) {
+    await markCompleted(account.fakeid);
+  }
+
+  // 调试输出：打印本批文章编号/标题/url
+  if (process.client) {
+    const debugList = articles.map((a, idx) => `${begin + idx + 1}: ${a.title} => ${a.link}`);
+    console.log(
+      `[profile_ext] ${account.nickname || account.fakeid} offset=${offsetParam} next_offset=${nextOffset} count=${articles.length}`,
+      debugList
+    );
+  }
+
+  return [articles, isCompleted, publish_page.total_count];
+}
+
+function ensureProfileExtSuccess(resp: ProfileExtResponse) {
+  const retCode = resp.base_resp?.ret ?? resp.ret ?? -1;
+  if (retCode !== 0) {
+    const msg = resp.base_resp?.err_msg || resp.errmsg || '获取文章列表失败';
+    throw new Error(`${retCode}:${msg}`);
+  }
+}
+
+function parseGeneralMsgList(general_msg_list?: string | ProfileExtList): ProfileExtList {
+  if (!general_msg_list) {
+    return { list: [], msg_count: 0 };
+  }
+  if (typeof general_msg_list !== 'string') {
+    return general_msg_list;
+  }
+  try {
+    return JSON.parse(general_msg_list);
+  } catch (e) {
+    console.error('解析 general_msg_list 失败', e);
+    return { list: [], msg_count: 0 };
+  }
+}
+
+function buildStubArticle(msg: ProfileExtItem, msgId: number, createTime: number): AppMsgEx {
+  return {
+    aid: `${msgId}_1`,
+    album_id: '',
+    appmsg_album_infos: [],
+    appmsgid: msgId,
+    author_name: '',
+    ban_flag: 0,
+    checking: 0,
+    copyright_stat: 0,
+    copyright_type: 0,
+    cover: '',
+    cover_img: '',
+    cover_img_theme_color: undefined,
+    create_time: createTime,
+    digest: msg.comm_msg_info?.content || '',
+    has_red_packet_cover: 0,
+    is_deleted: false,
+    is_pay_subscribe: 0,
+    item_show_type: 0,
+    itemidx: 1,
+    link: '',
+    media_duration: '',
+    mediaapi_publish_status: 0,
+    pic_cdn_url_1_1: '',
+    pic_cdn_url_3_4: '',
+    pic_cdn_url_16_9: '',
+    pic_cdn_url_235_1: '',
+    title: msg.comm_msg_info?.content || '公众号消息',
+    update_time: createTime,
+  };
+}
+
+function buildArticleFromProfileExt(
+  item: ProfileExtSubItem,
+  msgId: number,
+  itemidx: number,
+  createTime: number,
+  account: Info
+): AppMsgEx {
+  const link = item.content_url?.replace(/&amp;/g, '&') || '';
+  const cover = item.cover || '';
+  const author = item.author || account.nickname || '';
+  let copyrightStat: number = item.copyright_stat ?? 0;
+  let copyrightType: number = item.copyright_type ?? 0;
+
+  // profile_ext 返回中无版权字段时，默认按原创处理（source_url 为空且作者来自当前账号）
+  if (item.copyright_stat === undefined && item.copyright_type === undefined) {
+    const isReprint = Boolean(item.source_url);
+    copyrightStat = isReprint ? 0 : 1;
+    copyrightType = isReprint ? 0 : 1;
+  }
+
+  // 某些返回值使用 100 表示未知，兼容为非原创
+  if (copyrightStat === 100 && item.copyright_type === undefined) {
+    copyrightStat = 0;
+    copyrightType = 0;
+  }
+
+  const itemShowType = (item as any).item_show_type ?? (item as any).show_type ?? 0;
+  const isPaySubscribe = (item as any).is_pay_subscribe ?? 0;
+  const hasRedPacketCover = (item as any).has_red_packet_cover ?? 0;
+  return {
+    aid: `${msgId}_${itemidx}`,
+    album_id: '',
+    appmsg_album_infos: [],
+    appmsgid: msgId,
+    author_name: author,
+    ban_flag: 0,
+    checking: 0,
+    copyright_stat: copyrightStat,
+    copyright_type: copyrightType,
+    cover: cover,
+    cover_img: cover,
+    cover_img_theme_color: undefined,
+    create_time: createTime,
+    digest: item.digest || '',
+    has_red_packet_cover: hasRedPacketCover,
+    is_deleted: false,
+    is_pay_subscribe: isPaySubscribe,
+    item_show_type: itemShowType,
+    itemidx: itemidx,
+    link: link,
+    media_duration: '',
+    mediaapi_publish_status: 0,
+    pic_cdn_url_1_1: cover,
+    pic_cdn_url_3_4: cover,
+    pic_cdn_url_16_9: cover,
+    pic_cdn_url_235_1: cover,
+    title: item.title || '',
+    update_time: createTime,
+  };
 }
 
 /**

--- a/server/api/web/mp/appmsgpublish.get.ts
+++ b/server/api/web/mp/appmsgpublish.get.ts
@@ -2,8 +2,8 @@
  * 获取文章列表接口
  */
 
-import { proxyMpRequest } from '~/server/utils/proxy-request';
 import { getTokenFromStore } from '~/server/utils/CookieStore';
+import { proxyMpRequest } from '~/server/utils/proxy-request';
 
 interface AppMsgPublishQuery {
   begin?: number;
@@ -46,6 +46,7 @@ export default defineEventHandler(async event => {
     query: params,
     parseJson: true,
   }).catch(e => {
+    console.error('appmsgpublish.get.ts中获取文章列表出错');
     console.error(e);
     return {
       base_resp: {

--- a/server/api/web/mp/profile_ext.get.ts
+++ b/server/api/web/mp/profile_ext.get.ts
@@ -1,0 +1,43 @@
+import { proxyMpRequest } from '~/server/utils/proxy-request';
+
+interface ProfileExtQuery {
+  __biz: string;
+  pass_ticket: string;
+  key: string;
+  uin: string;
+  offset?: number | string;
+  count?: number | string;
+}
+
+export default defineEventHandler(async event => {
+  const query = getQuery<ProfileExtQuery>(event);
+
+  const params: Record<string, string | number> = {
+    action: 'getmsg',
+    f: 'json',
+    is_ok: 1,
+    count: query.count ?? 10,
+    offset: query.offset ?? 0,
+    __biz: query.__biz,
+    pass_ticket: query.pass_ticket,
+    key: query.key,
+    uin: query.uin,
+  };
+
+  return proxyMpRequest({
+    event,
+    method: 'GET',
+    endpoint: 'https://mp.weixin.qq.com/mp/profile_ext',
+    query: params,
+    parseJson: true,
+  }).catch(e => {
+    console.error('profile_ext.get.ts 请求公众号文章列表失败');
+    console.error(e);
+    return {
+      base_resp: {
+        ret: -1,
+        err_msg: '获取文章列表失败，请重试',
+      },
+    };
+  });
+});

--- a/store/v2/article.ts
+++ b/store/v2/article.ts
@@ -1,4 +1,4 @@
-import type { PublishInfo, PublishPage, AppMsgExWithFakeID } from '~/types/types';
+import type { AppMsgExWithFakeID, PublishInfo, PublishPage } from '~/types/types';
 import { db } from './db';
 import { type Info, updateInfoCache } from './info';
 
@@ -47,6 +47,7 @@ export async function updateArticleCache(account: Info, publish_page: PublishPag
       nickname: account.nickname,
       round_head_img: account.round_head_img,
       total_count: total_count,
+      hidden: account.hidden,
     });
   });
 }
@@ -77,6 +78,60 @@ export async function getArticleCache(fakeid: string, create_time: number): Prom
     .and(article => article.create_time < create_time)
     .reverse()
     .sortBy('create_time');
+}
+
+/**
+ * 检查是否存在同标题且发布时间（精确到小时）相同的文章
+ * @param fakeid
+ * @param title
+ * @param create_time
+ */
+export async function articleExistsByTitleAndTime(
+  fakeid: string,
+  title: string,
+  create_time: number
+): Promise<boolean> {
+  const hourBucket = Math.floor(create_time / 3600);
+  const count = await db.article
+    .where('fakeid')
+    .equals(fakeid)
+    .filter(a => {
+      if (!a.title) return false;
+      const aHourBucket = Math.floor((a.create_time || 0) / 3600);
+      return a.title === title && aHourBucket === hourBucket;
+    })
+    .count();
+  return count > 0;
+}
+
+/**
+ * 检查当前文章的link是否已经存在
+ * @param link
+ * @returns
+ */
+export async function articleExistsByLink(link: string): Promise<boolean> {
+  const url = new URL(link);
+  const biz = url.searchParams.get('__biz');
+  const mid = url.searchParams.get('mid');
+  const sn = url.searchParams.get('sn');
+  if (!biz || !mid || !sn) {
+    // fallback to full link match
+    const count = await db.article.where('link').equals(link).count();
+    return count > 0;
+  }
+  const count = await db.article
+    .filter(a => {
+      try {
+        const u = new URL(a.link);
+        return (
+          u.searchParams.get('__biz') === biz && u.searchParams.get('mid') === mid && u.searchParams.get('sn') === sn
+        );
+      } catch {
+        return false;
+      }
+    })
+    .count();
+  return count > 0;
 }
 
 /**


### PR DESCRIPTION
1、新增对禁止搜索的公众号文章抓取的支持，原来会抛出200002:invalid args异常
2、禁止搜索的公众号的部分文章可以通过单篇文章的方式抓取，抓取后会合并到公众号文章的管理中