### PR TITLE
🐛 fix(download): 修复图片懒加载属性未被转换的问题

### DIFF
--- a/utils/download/Exporter.ts
+++ b/utils/download/Exporter.ts
@@ -379,16 +379,7 @@ export class Exporter extends BaseDownload {
       if (!content) {
         continue;
       }
-      const doc = parser.parseFromString(content, 'text/html');
-      const imgs = doc.querySelectorAll<HTMLImageElement>('img');
-      imgs.forEach(img => {
-        const src = img.getAttribute('src');
-        const dataSrc = img.getAttribute('data-src');
-        if (!src && dataSrc) {
-          img.setAttribute('src', dataSrc);
-        }
-      });
-      const markdown = turndownService.turndown(doc.body);
+      const markdown = turndownService.turndown(content);
 
       const blob = new Blob([markdown], { type: 'text/markdown' });
       await this.writeFile(filename + '.md', blob);
@@ -444,6 +435,16 @@ export class Exporter extends BaseDownload {
     });
     $jsArticleContent.querySelector('#js_pc_qr_code')?.remove();
     $jsArticleContent.querySelector('#wx_stream_article_slide_tip')?.remove();
+
+    // 图片懒加载：将 data-src 回填到 src，便于导出
+    const imgs = $jsArticleContent.querySelectorAll<HTMLImageElement>('img');
+    imgs.forEach(img => {
+      const src = img.getAttribute('src');
+      const dataSrc = img.getAttribute('data-src');
+      if (!src && dataSrc) {
+        img.setAttribute('src', dataSrc);
+      }
+    });
 
     // 文本分享消息补充
     const $js_text_desc = $jsArticleContent.querySelector('#js_text_desc') as HTMLElement | null;


### PR DESCRIPTION


示例文章： https://mp.weixin.qq.com/s/8pz641EObaXQs2cstJiHKg

导出 markdown 以后，会发现除了第一张图片，其余都是缺失的。


本次修复在 HTML 转 Markdown 前，将图片的 data-src属性复制到 src 属性，确保懒加载图片能正确导出。

该修复在本地运行已验证。

close #95