### PR TITLE
fix: harden auth cookie expiration handling

### DIFF
--- a/server/utils/CookieStore.ts
+++ b/server/utils/CookieStore.ts
@@ -1,5 +1,6 @@
 import { H3Event, parseCookies } from 'h3';
 import { CookieKVValue, getMpCookie, setMpCookie } from '~/server/kv/cookie';
+import { getCookieExpirationState } from './cookie-expiration';
 
 // 表示一条 set-cookie 记录的解析结果
 export type CookieEntity = Record<string, string | number>;
@@ -45,8 +46,7 @@ export class AccountCookie {
 
   // 根据 cookie 中的 expires 来确定是否已过期
   public get isExpired(): boolean {
-    // todo
-    return false;
+    return getCookieExpirationState(this._cookie) === 'expired';
   }
 
   public static parse(cookies: string[]): CookieEntity[] {
@@ -120,6 +120,11 @@ class CookieStore {
     let cachedAccountCookie = this.store.get(authKey);
 
     if (cachedAccountCookie) {
+      if (cachedAccountCookie.isExpired) {
+        this.store.delete(authKey);
+        return null;
+      }
+
       // LRU: 访问时将条目移到末尾（最近使用）
       this.store.delete(authKey);
       this.store.set(authKey, cachedAccountCookie);
@@ -133,6 +138,10 @@ class CookieStore {
     }
 
     cachedAccountCookie = AccountCookie.create(cookieValue.token, cookieValue.cookies);
+    if (cachedAccountCookie.isExpired) {
+      return null;
+    }
+
     this.evictIfNeeded();
     this.store.set(authKey, cachedAccountCookie);
 

--- a/server/utils/cookie-expiration.ts
+++ b/server/utils/cookie-expiration.ts
@@ -1,0 +1,43 @@
+export type CookieExpirationState = 'active' | 'expired';
+
+type CookieWithExpiration = {
+  name?: string | number;
+  value?: string | number;
+  expires?: string | number;
+  expires_timestamp?: string | number;
+};
+
+function getExpiresTimestamp(cookie: CookieWithExpiration): number | null {
+  if (typeof cookie.expires_timestamp === 'number') {
+    return cookie.expires_timestamp;
+  }
+
+  if (typeof cookie.expires_timestamp === 'string') {
+    const timestamp = Number(cookie.expires_timestamp);
+    return Number.isFinite(timestamp) ? timestamp : null;
+  }
+
+  if (typeof cookie.expires === 'string' || typeof cookie.expires === 'number') {
+    const timestamp = Date.parse(String(cookie.expires));
+    return Number.isNaN(timestamp) ? null : timestamp;
+  }
+
+  return null;
+}
+
+export function getCookieExpirationState(cookies: CookieWithExpiration[], now = Date.now()): CookieExpirationState {
+  if (cookies.length === 0) {
+    return 'expired';
+  }
+
+  const hasActiveCookie = cookies.some(cookie => {
+    if (!cookie.value || cookie.value === 'EXPIRED') {
+      return false;
+    }
+
+    const expiresTimestamp = getExpiresTimestamp(cookie);
+    return expiresTimestamp === null || expiresTimestamp > now;
+  });
+
+  return hasActiveCookie ? 'active' : 'expired';
+}

--- a/server/utils/proxy-request.ts
+++ b/server/utils/proxy-request.ts
@@ -85,7 +85,6 @@ export async function proxyMpRequest(options: RequestOptions) {
         throw new Error(`redirect_url 中未找到 token 参数: ${redirectUrl}`);
       }
 
-      console.log('token', token);
       const success = await cookieStore.setCookie(authKey, token, mpResponse.headers.getSetCookie());
       if (!success) {
         throw new Error('cookie 写入 KV 存储失败');
@@ -93,10 +92,10 @@ export async function proxyMpRequest(options: RequestOptions) {
       console.log('cookie 写入成功');
 
       setCookies = [
-        `auth-key=${authKey}; Path=/; Expires=${dayjs().add(4, 'days').toString()}; Secure; HttpOnly`,
+        `auth-key=${authKey}; Path=/; Expires=${dayjs().add(4, 'days').toString()}; Secure; HttpOnly; SameSite=Lax`,
 
         // 登录成功后，删除浏览器的 uuid cookie
-        `uuid=EXPIRED; Path=/; Expires=${dayjs().subtract(1, 'days').toString()}; Secure; HttpOnly`,
+        `uuid=EXPIRED; Path=/; Expires=${dayjs().subtract(1, 'days').toString()}; Secure; HttpOnly; SameSite=Lax`,
       ];
     } catch (error) {
       console.error('action(login) failed:', error);

--- a/test/cookie-expiration.test.ts
+++ b/test/cookie-expiration.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getCookieExpirationState } from '../server/utils/cookie-expiration.ts';
+
+test('cookie collection without expiration metadata stays active', () => {
+  const state = getCookieExpirationState(
+    [{ name: 'session', value: 'abc' }],
+    new Date('2026-01-01T00:00:00Z').getTime()
+  );
+
+  assert.equal(state, 'active');
+});
+
+test('cookie collection is expired when every expiring cookie is expired', () => {
+  const now = new Date('2026-01-01T00:00:00Z').getTime();
+
+  const state = getCookieExpirationState(
+    [
+      { name: 'old-session', value: 'abc', expires_timestamp: now - 1 },
+      { name: 'expired-marker', value: 'EXPIRED' },
+    ],
+    now
+  );
+
+  assert.equal(state, 'expired');
+});
+
+test('cookie collection remains active while any expiring cookie is still valid', () => {
+  const now = new Date('2026-01-01T00:00:00Z').getTime();
+
+  const state = getCookieExpirationState(
+    [
+      { name: 'old-session', value: 'abc', expires_timestamp: now - 1 },
+      { name: 'fresh-session', value: 'def', expires_timestamp: now + 1 },
+    ],
+    now
+  );
+
+  assert.equal(state, 'active');
+});


### PR DESCRIPTION
This change improves authentication cookie hygiene by adding expiration-state detection for stored MP cookies and avoiding reuse of expired auth cache entries. It also removes plaintext token logging during login and adds SameSite=Lax to internal auth cookies.

Verified with:
- node --test ./test/cookie-expiration.test.ts
- yarn biome check ...
- yarn build