### PR TITLE
fix: 识别并标记隐私保护文章（仅内部分享可见）

### DIFF
--- a/shared/utils/html.ts
+++ b/shared/utils/html.ts
@@ -119,6 +119,11 @@ export function validateHTMLContent(html: string): ['Success' | 'Deleted' | 'Exc
   } else if ($msgBlock.length === 1) {
     const msg = $msgBlock.text().trim().replace(/\n+/g, '').replace(/ +/g, ' ');
     return ['Exception', msg];
+  } else if ($('#app').length === 1) {
+    // 隐私文章（SPA 页面，内容通过 Vue 动态加载，无内嵌 HTML 结构）
+    // 特征: <div id="app"></div> 作为挂载点，body 类含 appmsg_skin_default，
+    // 使用 vite + vue 构建的 JS 包 private.*.js 动态渲染内容
+    return ['Exception', '隐私保护，仅内部分享可见'];
   } else {
     return ['Error', null];
   }


### PR DESCRIPTION
## 问题描述

有的文章抓取后，文章状态显示为空。这是因为微信公众号新增了一种 **SPA 隐私文章** 页面类型，内容通过 Vue 动态加载（vite + vue 构建），页面不包含传统的 `#js_article` 元素和 `window.cgiDataNew` 数据。

当前 `validateHTMLContent` 无法识别这种页面类型，走到最后一个 `else` 分支返回 `['Error', null]`，导致：
1. `_status` 字段永远不会被更新（始终为空）
2. 用户只能看到空的状态，不知道文章为何不可用

## 分析

抓取示例文章并分析 HTML 结构发现：
- 传统文章: 包含 `<div id="js_article">` 和内嵌的 `window.cgiDataNew`
- SPA 隐私文章: 使用 `<div id="app"></div>` 作为 Vue 挂载点，内容通过 `private.*.js` JS 包动态加载
- 页面 body 类包含 `appmsg_skin_default appmsg_style_default`
- 没有包含文章内容的 HTML 结构

## 修复

在 `validateHTMLContent` 中新增检测逻辑：当页面包含 `<div id="app">` 挂载点（且不匹配前面已知结构）时，返回 `['Exception', '隐私保护，仅内部分享可见']`。

通过已有的异常处理链：
`validateHTMLContent → Exception with msg → download:exception → onStatusChange → updateArticleStatus`

正确地将文章的 `_status` 更新为「隐私保护，仅内部分享可见」，让用户在表格中直观地看到文章状态。

## 测试

- [x] 正常文章（含 `#js_article`）：仍返回 `Success`
- [x] 已删除文章（`.weui-msg` 含删除提示）：仍返回 `Deleted`
- [x] 隐私文章（含 `<div id="app">`，无 `#js_article`）：返回 `Exception` + 提示信息
- [x] 环境异常（`.weui-msg` 含其他提示）：仍返回 `Exception`
- [x] 正常文章同时含 `#app` 容器：`#js_article` 优先匹配，仍返回 `Success`
- [x] 未知页面：仍返回 `Error`

## 相关 issue

Fixes #（issue 号，如有）
