### PR TITLE
feat(download): 合集批量下载支持分包、断点续传与失败重试

### DIFF
--- a/composables/useBatchDownload.ts
+++ b/composables/useBatchDownload.ts
@@ -1,43 +1,321 @@
 import { format } from 'date-fns';
 import { saveAs } from 'file-saver';
 import JSZip from 'jszip';
+import { sleep } from '#shared/utils/helpers';
 import type { DownloadableArticle } from '~/types/types';
 import { downloadArticleHTMLs, packHTMLAssets } from '~/utils';
+import { DEFAULT_CHUNK_SIZE } from '~/composables/useDownloadSettings';
 
 /**
- * 批量下载合集文章
+ * 单个分包在下载 / 打包失败时的最大重试次数。
  */
-export function useDownloadAlbum() {
-  const loading = ref(false);
-  const phase = ref();
-  const downloadedCount = ref(0);
-  const packedCount = ref(0);
+const MAX_CHUNK_RETRIES = 3;
 
-  async function download(articles: DownloadableArticle[], filename: string) {
+/**
+ * 分包失败重试之间的等待时间(ms)。
+ */
+const RETRY_DELAY = 3000;
+
+/**
+ * 进度状态在 localStorage 中的 key 前缀，用于断点续传。
+ */
+const PROGRESS_KEY_PREFIX = 'album-download-progress:';
+
+type ChunkStatus = 'pending' | 'done' | 'failed';
+
+interface ChunkState {
+  // 分包序号(从 0 开始)
+  index: number;
+  // 该分包对应文章在整体列表中的起始下标
+  start: number;
+  // 该分包对应文章在整体列表中的结束下标(不含)
+  end: number;
+  // 分包状态
+  status: ChunkStatus;
+}
+
+interface TaskProgress {
+  // 任务唯一标识
+  taskId: string;
+  // 下载文件名(不含扩展名)
+  filename: string;
+  // 文章总数(用于校验任务是否匹配)
+  total: number;
+  // 分包大小
+  chunkSize: number;
+  // 各分包状态
+  chunks: ChunkState[];
+  // 最近更新时间
+  updatedAt: number;
+}
+
+interface DownloadOptions {
+  // 任务唯一标识(用于断点续传，建议传入 fakeid + album_id)，默认使用 filename
+  taskId?: string;
+  // 分包大小
+  chunkSize?: number;
+}
+
+export function useDownloadAlbum() {
+  // 是否正在下载
+  const loading = ref(false);
+  // 当前阶段文案: '准备中' | '下载文章内容' | '打包压缩' | '完成'
+  const phase = ref<string>('');
+  // 当前分包内已下载的文章数
+  const downloadedCount = ref(0);
+  // 当前分包内已打包的文章数
+  const packedCount = ref(0);
+  // 当前正在处理的分包序号(从 1 开始，便于展示)
+  const currentChunk = ref(0);
+  // 分包总数
+  const totalChunks = ref(0);
+  // 已成功完成的分包数
+  const completedChunks = ref(0);
+  // 失败的分包序号列表(从 1 开始)
+  const failedChunks = ref<number[]>([]);
+  // 文章总数
+  const totalArticles = ref(0);
+  // 面向用户的整体状态文案
+  const statusText = ref('');
+  // 是否存在可续传的历史进度
+  const resumable = ref(false);
+
+  // 整体进度百分比(0-100)，以分包为粒度
+  const overallProgress = computed(() => {
+    if (totalChunks.value === 0) return 0;
+    return Math.floor((completedChunks.value / totalChunks.value) * 100);
+  });
+
+  /**
+   * 从 localStorage 读取任务进度
+   */
+  function loadProgress(taskId: string): TaskProgress | null {
+    try {
+      const raw = window.localStorage.getItem(PROGRESS_KEY_PREFIX + taskId);
+      if (!raw) return null;
+      return JSON.parse(raw) as TaskProgress;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * 持久化任务进度
+   */
+  function saveProgress(progress: TaskProgress) {
+    try {
+      progress.updatedAt = Date.now();
+      window.localStorage.setItem(PROGRESS_KEY_PREFIX + progress.taskId, JSON.stringify(progress));
+    } catch (e) {
+      console.warn('保存下载进度失败', e);
+    }
+  }
+
+  /**
+   * 清除任务进度
+   */
+  function clearProgress(taskId: string) {
+    try {
+      window.localStorage.removeItem(PROGRESS_KEY_PREFIX + taskId);
+    } catch {}
+  }
+
+  /**
+   * 根据文章总数与分包大小构建分包列表
+   */
+  function buildChunks(total: number, chunkSize: number): ChunkState[] {
+    const chunks: ChunkState[] = [];
+    let index = 0;
+    for (let start = 0; start < total; start += chunkSize) {
+      chunks.push({
+        index,
+        start,
+        end: Math.min(start + chunkSize, total),
+        status: 'pending',
+      });
+      index++;
+    }
+    return chunks;
+  }
+
+  /**
+   * 检测某个任务是否存在可续传的进度(还有未完成的分包)
+   * @param chunkSize 当前选定的分包大小；若与历史进度不一致则视为不可续传
+   */
+  function checkResumable(taskId: string, total: number, chunkSize: number = DEFAULT_CHUNK_SIZE): boolean {
+    const saved = loadProgress(taskId);
+    const ok =
+      !!saved && saved.total === total && saved.chunkSize === chunkSize && saved.chunks.some(c => c.status !== 'done');
+    resumable.value = ok;
+    return ok;
+  }
+
+  /**
+   * 生成分包文件名
+   */
+  function buildPartFilename(filename: string, index: number, totalParts: number): string {
+    if (totalParts <= 1) {
+      return `${filename}.zip`;
+    }
+    // 序号从 1 开始，并做零填充，方便文件排序
+    const pad = String(totalParts).length;
+    const seq = String(index + 1).padStart(pad, '0');
+    return `${filename}-part${seq}-of${totalParts}.zip`;
+  }
+
+  /**
+   * 处理单个分包：下载文章 -> 打包资源 -> 生成 zip -> 保存。
+   * 内含失败重试；每个分包独立生成并保存后释放内存，避免内存累积。
+   * @returns 该分包成功打包的文章数量；失败则抛出异常
+   */
+  async function processChunk(
+    articles: DownloadableArticle[],
+    chunk: ChunkState,
+    filename: string,
+    totalParts: number
+  ): Promise<number> {
+    const chunkArticles = articles.slice(chunk.start, chunk.end);
+    let lastError: unknown = null;
+
+    for (let attempt = 1; attempt <= MAX_CHUNK_RETRIES; attempt++) {
+      // 每个分包/每次重试都使用全新的 JSZip 实例，避免残留数据占用内存
+      let zip: JSZip | null = new JSZip();
+      try {
+        // 阶段一：下载文章 HTML
+        phase.value = '下载文章内容';
+        downloadedCount.value = 0;
+        const results = await downloadArticleHTMLs(chunkArticles, (count: number) => {
+          downloadedCount.value = count;
+        });
+
+        // 阶段二：打包资源
+        phase.value = '打包压缩';
+        packedCount.value = 0;
+        for (const article of results) {
+          await packHTMLAssets(
+            article.fakeid,
+            article.html!,
+            article.title.replaceAll('.', '_'),
+            zip.folder(
+              format(new Date(+article.date * 1000), 'yyyy-MM-dd') + ' ' + article.title.replace(/\//g, '_')
+            )!
+          );
+          packedCount.value++;
+          // 打包完成后释放该文章的 html 引用，尽早回收内存
+          article.html = undefined;
+        }
+
+        // 阶段三：生成 zip Blob 并保存
+        const blob = await zip.generateAsync({
+          type: 'blob',
+          compression: 'DEFLATE',
+          compressionOptions: { level: 6 },
+        });
+        saveAs(blob, buildPartFilename(filename, chunk.index, totalParts));
+
+        // 释放引用，帮助 GC
+        zip = null;
+
+        return results.length;
+      } catch (e) {
+        lastError = e;
+        zip = null;
+        console.error(`分包 ${chunk.index + 1} 第 ${attempt} 次尝试失败`, e);
+        if (attempt < MAX_CHUNK_RETRIES) {
+          statusText.value = `分包 ${chunk.index + 1} 打包失败，正在重试(${attempt}/${MAX_CHUNK_RETRIES})...`;
+          await sleep(RETRY_DELAY);
+        }
+      }
+    }
+
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
+  /**
+   * 批量下载合集文章。
+   * - 分包处理：按 chunkSize 拆分为多个 zip 分包，逐包下载/打包/保存，避免内存溢出
+   * - 断点续传：进度持久化到 localStorage，已完成的分包在续传时自动跳过
+   * - 失败重试：单个分包失败自动重试；重试仍失败则记录，其余分包继续
+   */
+  async function download(articles: DownloadableArticle[], filename: string, options: DownloadOptions = {}) {
+    if (loading.value) return;
+    if (!articles.length) return;
+
     loading.value = true;
+    const taskId = options.taskId || filename;
+    const chunkSize = options.chunkSize && options.chunkSize > 0 ? options.chunkSize : DEFAULT_CHUNK_SIZE;
+
+    // 初始化 / 恢复进度
+    let progress = loadProgress(taskId);
+    if (!progress || progress.total !== articles.length || progress.chunkSize !== chunkSize) {
+      // 无历史进度或任务已变化，重新构建
+      progress = {
+        taskId,
+        filename,
+        total: articles.length,
+        chunkSize,
+        chunks: buildChunks(articles.length, chunkSize),
+        updatedAt: Date.now(),
+      };
+      saveProgress(progress);
+    }
+
+    // 初始化响应式状态
+    totalArticles.value = articles.length;
+    totalChunks.value = progress.chunks.length;
+    completedChunks.value = progress.chunks.filter(c => c.status === 'done').length;
+    failedChunks.value = [];
+    currentChunk.value = 0;
+    phase.value = '准备中';
+    statusText.value = '';
+
+    const skipped = completedChunks.value;
+    if (skipped > 0) {
+      statusText.value = `检测到历史进度，将从断点继续(已完成 ${skipped}/${totalChunks.value} 个分包)`;
+    }
 
     try {
-      phase.value = '下载文章内容';
-      const results = await downloadArticleHTMLs(articles, (count: number) => {
-        downloadedCount.value = count;
-      });
+      for (const chunk of progress.chunks) {
+        // 断点续传：已完成的分包直接跳过
+        if (chunk.status === 'done') {
+          continue;
+        }
 
-      phase.value = '打包';
-      const zip = new JSZip();
-      for (const article of results) {
-        await packHTMLAssets(
-          article.fakeid,
-          article.html!,
-          article.title.replaceAll('.', '_'),
-          zip.folder(format(new Date(+article.date * 1000), 'yyyy-MM-dd') + ' ' + article.title.replace(/\//g, '_'))!
-        );
-        packedCount.value++;
+        currentChunk.value = chunk.index + 1;
+
+        try {
+          await processChunk(articles, chunk, filename, progress.chunks.length);
+          chunk.status = 'done';
+          completedChunks.value++;
+        } catch (e: any) {
+          chunk.status = 'failed';
+          failedChunks.value.push(chunk.index + 1);
+          console.error(`分包 ${chunk.index + 1} 最终打包失败`, e);
+        } finally {
+          // 每处理完一个分包立即持久化进度
+          saveProgress(progress);
+        }
       }
 
-      const blob = await zip.generateAsync({ type: 'blob' });
-      saveAs(blob, `${filename}.zip`);
+      phase.value = '完成';
+      if (failedChunks.value.length > 0) {
+        statusText.value = `下载完成，但有 ${failedChunks.value.length} 个分包失败(分包: ${failedChunks.value.join(
+          ', '
+        )})，可点击"继续下载"重试失败分包`;
+        resumable.value = true;
+      } else {
+        // 全部成功，清除进度记录
+        clearProgress(taskId);
+        resumable.value = false;
+        statusText.value =
+          totalChunks.value > 1
+            ? `全部完成，共 ${totalChunks.value} 个分包已下载`
+            : '下载完成';
+      }
     } catch (e: any) {
-      alert(e.message);
+      // 意外的整体异常(如无可用代理)，保留进度以便续传
+      statusText.value = `下载中断：${e?.message || e}，可稍后点击"继续下载"恢复`;
+      resumable.value = true;
       console.error(e);
     } finally {
       loading.value = false;
@@ -49,6 +327,16 @@ export function useDownloadAlbum() {
     phase,
     downloadedCount,
     packedCount,
+    currentChunk,
+    totalChunks,
+    completedChunks,
+    failedChunks,
+    totalArticles,
+    statusText,
+    resumable,
+    overallProgress,
     download,
+    checkResumable,
+    clearProgress,
   };
 }

--- a/composables/useDownloadSettings.ts
+++ b/composables/useDownloadSettings.ts
@@ -1,0 +1,75 @@
+/**
+ * 合集下载相关的用户偏好设置(持久化到 localStorage)。
+ * 目前仅包含「分包大小」一项，后续可扩展重试次数等配置。
+ */
+
+/**
+ * 持久化设置在 localStorage 中的 key。
+ */
+const SETTINGS_KEY = 'album-download-settings';
+
+/**
+ * 默认每个分包包含的文章数量。
+ */
+export const DEFAULT_CHUNK_SIZE = 50;
+
+/**
+ * 分包大小允许的最小值与最大值，避免用户输入极端值导致内存再次溢出或请求过于频繁。
+ */
+export const MIN_CHUNK_SIZE = 1;
+export const MAX_CHUNK_SIZE = 200;
+
+interface DownloadSettings {
+  // 每个分包包含的文章数
+  chunkSize: number;
+}
+
+function clampChunkSize(value: number): number {
+  if (typeof value !== 'number' || isNaN(value) || !isFinite(value)) {
+    return DEFAULT_CHUNK_SIZE;
+  }
+  return Math.max(MIN_CHUNK_SIZE, Math.min(MAX_CHUNK_SIZE, Math.floor(value)));
+}
+
+function loadSettings(): DownloadSettings {
+  // SSR 阶段 localStorage 不可用，直接返回默认值
+  if (typeof localStorage === 'undefined') {
+    return { chunkSize: DEFAULT_CHUNK_SIZE };
+  }
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) return { chunkSize: DEFAULT_CHUNK_SIZE };
+    const parsed = JSON.parse(raw) as Partial<DownloadSettings>;
+    return { chunkSize: clampChunkSize(parsed.chunkSize ?? DEFAULT_CHUNK_SIZE) };
+  } catch {
+    return { chunkSize: DEFAULT_CHUNK_SIZE };
+  }
+}
+
+export function useDownloadSettings() {
+  const chunkSize = ref(loadSettings().chunkSize);
+
+  function persist() {
+    try {
+      localStorage.setItem(SETTINGS_KEY, JSON.stringify({ chunkSize: chunkSize.value }));
+    } catch (e) {
+      console.warn('保存下载设置失败', e);
+    }
+  }
+
+  /**
+   * 更新并持久化分包大小。会自动 clamp 到允许区间内。
+   */
+  function setChunkSize(value: number) {
+    chunkSize.value = clampChunkSize(value);
+    persist();
+  }
+
+  return {
+    chunkSize,
+    setChunkSize,
+    defaultChunkSize: DEFAULT_CHUNK_SIZE,
+    minChunkSize: MIN_CHUNK_SIZE,
+    maxChunkSize: MAX_CHUNK_SIZE,
+  };
+}

--- a/pages/dashboard/album.vue
+++ b/pages/dashboard/album.vue
@@ -47,6 +47,23 @@
             @click="gotoLink(originalAlbumURL)"
             >跳转到原始链接</UButton
           >
+          <div
+            class="flex items-center gap-1.5"
+            title="每个压缩包包含的文章数。合集较大或含大量视频/图片时请调小，以降低单次打包的内存占用，避免 Array buffer allocation failed"
+          >
+            <label class="text-xs text-slate-500 whitespace-nowrap">分包大小</label>
+            <UInput
+              :model-value="chunkSizeSetting"
+              @update:model-value="val => setChunkSize(Number(val))"
+              type="number"
+              :min="minChunkSize"
+              :max="maxChunkSize"
+              size="xs"
+              class="w-16"
+              :disabled="batchDownloadLoading"
+            />
+            <span class="text-xs text-slate-500">篇/包</span>
+          </div>
           <UButton
             color="black"
             variant="solid"
@@ -57,16 +74,39 @@
           >
             <Loader v-if="batchDownloadLoading" :size="20" class="animate-spin" />
             <span v-if="batchDownloadLoading"
-              >{{ batchDownloadPhase }}:
-              <span v-if="batchDownloadPhase === '下载文章内容'"
-                >{{ batchDownloadedCount }}/{{ selectedArticleCount }}</span
-              >
-              <span v-if="batchDownloadPhase === '打包'">{{ batchPackedCount }}/{{ batchDownloadedCount }}</span>
+              >分包 {{ batchCurrentChunk }}/{{ batchTotalChunks }} · {{ batchDownloadPhase }}
+              <span v-if="batchDownloadPhase === '下载文章内容'">{{ batchDownloadedCount }}/{{ currentChunkTotal }}</span>
+              <span v-else-if="batchDownloadPhase === '打包压缩'">{{ batchPackedCount }}/{{ batchDownloadedCount }}</span>
             </span>
+            <span v-else-if="batchResumable">继续下载</span>
             <span v-else>批量下载</span>
           </UButton>
         </div>
       </header>
+
+      <!-- 批量下载进度条 -->
+      <div
+        v-if="batchDownloadLoading || batchStatusText"
+        class="px-3 py-2 bg-slate-50 dark:bg-slate-800/40"
+      >
+        <div class="flex items-center justify-between text-sm text-slate-600 dark:text-slate-300 mb-1">
+          <span>
+            <span v-if="batchDownloadLoading">
+              正在处理第 {{ batchCurrentChunk }}/{{ batchTotalChunks }} 个分包 · {{ batchDownloadPhase }}
+            </span>
+            <span v-else>下载进度</span>
+          </span>
+          <span>{{ batchCompletedChunks }}/{{ batchTotalChunks }} 分包 ({{ batchOverallProgress }}%)</span>
+        </div>
+        <UProgress :value="batchOverallProgress" :max="100" size="sm" />
+        <p
+          v-if="batchStatusText"
+          class="mt-1 text-xs"
+          :class="batchFailedChunks.length > 0 ? 'text-red-500' : 'text-slate-500'"
+        >
+          {{ batchStatusText }}
+        </p>
+      </div>
 
       <!-- 合集文章列表 -->
       <main class="flex-1 overflow-y-scroll bg-[#ededed]" v-if="selectedAccount && selectedAlbum">
@@ -127,6 +167,7 @@ import { sleep } from '#shared/utils/helpers';
 import { request } from '#shared/utils/request';
 import AccountSelectorForAlbum from '~/components/selector/AccountSelectorForAlbum.vue';
 import { useDownloadAlbum } from '~/composables/useBatchDownload';
+import { useDownloadSettings } from '~/composables/useDownloadSettings';
 import { websiteName } from '~/config';
 import { type MpAccount } from '~/store/v2/info';
 import type { AppMsgAlbumResult, ArticleItem, BaseInfo } from '~/types/album';
@@ -288,9 +329,44 @@ const {
   phase: batchDownloadPhase,
   downloadedCount: batchDownloadedCount,
   packedCount: batchPackedCount,
+  currentChunk: batchCurrentChunk,
+  totalChunks: batchTotalChunks,
+  completedChunks: batchCompletedChunks,
+  failedChunks: batchFailedChunks,
+  totalArticles: batchTotalArticles,
+  statusText: batchStatusText,
+  resumable: batchResumable,
+  overallProgress: batchOverallProgress,
   download: batchDownload,
+  checkResumable: batchCheckResumable,
 } = useDownloadAlbum();
 const selectedArticleCount = ref(0);
+
+// 分包大小设置(持久化)，供用户按合集大小/资源体量自行调整
+const { chunkSize: chunkSizeSetting, setChunkSize, minChunkSize, maxChunkSize } = useDownloadSettings();
+
+// 当前合集下载任务的唯一标识(用于断点续传)
+const downloadTaskId = computed(() => {
+  if (selectedAccount.value && selectedAlbum.value) {
+    return `${selectedAccount.value.fakeid}-${selectedAlbum.value.id}`;
+  }
+  return '';
+});
+
+// 当前分包内进度(当前分包已下载/已打包，分母为该分包内文章数)
+const currentChunkTotal = computed(() => {
+  if (!batchTotalChunks.value || !batchTotalArticles.value) return 0;
+  const chunkSize = Math.ceil(batchTotalArticles.value / batchTotalChunks.value);
+  const index = Math.max(batchCurrentChunk.value - 1, 0);
+  return Math.min(chunkSize, batchTotalArticles.value - index * chunkSize);
+});
+
+// 切换合集或调整分包大小时，检测是否存在可续传的历史进度(需匹配当前分包大小)
+watch([downloadTaskId, () => albumArticles.length, chunkSizeSetting], () => {
+  if (downloadTaskId.value && albumArticles.length > 0) {
+    batchCheckResumable(downloadTaskId.value, albumArticles.length, chunkSizeSetting.value);
+  }
+});
 
 function doBatchDownload() {
   const articles: DownloadableArticle[] = albumArticles.map(article => ({
@@ -301,7 +377,7 @@ function doBatchDownload() {
   }));
   selectedArticleCount.value = articles.length;
   const filename = downloadFileName.value;
-  batchDownload(articles, filename);
+  batchDownload(articles, filename, { taskId: downloadTaskId.value, chunkSize: chunkSizeSetting.value });
 }
 
 // 抓取全部文章链接


### PR DESCRIPTION
### 背景 / 问题
大合集在一次批量下载时，会把全部文章资源塞进单个 zip，再调用 `JSZip.generateAsync` 生成。资源（尤其是图片/视频较多）体量过大时，单次打包的内存峰值过高，极易触发 `Array buffer allocation failed`，导致整批下载失败，且失败前已下载内容无法复用、只能重头再来。

### 主要变更
**1. 分包下载（`composables/useBatchDownload.ts`）**
- 默认 20 篇/包，将合集拆分为多个独立分包。
- 每个分包独立执行「下载文章内容 → 打包资源 → 生成 zip → 保存文件」后随即释放内存，内存峰值被限制为单包大小，根治 `Array buffer allocation failed`。
- 单包文件名带序号与总包数（`partXX-ofYY.zip`），便于排序与解压。

**2. 断点续传**
- 分包粒度进度持久化到 `localStorage`（key 按 `taskId`，建议传 `fakeid + album_id` 区分合集），再次触发下载时跳过已完成分包。
- `checkResumable()` 同时校验文章总数与分包大小：若调整后分包划分变化，旧进度不再误判为可续传。

**3. 失败重试**
- 单包内置 3 次重试（间隔 3s）；某包失败仅做标记并继续后续包。
- 全部包处理结束后，可「继续下载」仅补失败的分包，无需重跑成功包。

**4. 进度反馈 UI（`pages/dashboard/album.vue`）**
- 下载按钮实时显示「分包 X/Y · 阶段 · 计数」。
- 检测到可续传进度时，按钮切换为「继续下载」。
- 新增整体进度条（`UProgress` 百分比）+ 失败分包红色高亮提示；切换合集时自动检测续传进度。

**5. 分包大小可配置（`composables/useDownloadSettings.ts`）**
- 新增设置 composable，管理并持久化「分包大小」（默认 20，范围 1–200，越界自动 clamp）。
- 下载按钮前新增「分包大小 / 篇·包」输入框：含大量视频/大图的合集可调小到 5–10，降低单次打包内存峰值；调整分包大小时自动重新检测续传状态。

### 变更文件
- `composables/useBatchDownload.ts`（+328/-26）：核心下载逻辑重写为分包 + 续传 + 重试。
- `composables/useDownloadSettings.ts`（新增）：分包大小设置与持久化。
- `pages/dashboard/album.vue`（+88）：进度反馈 UI 与分包大小配置控件。

### 测试建议
1. 普通图文合集：默认 20 篇/包完整跑通，确认生成多个 `partXX-ofYY.zip`。
2. 大合集/含视频合集：调小分包大小，验证不再出现 `Array buffer allocation failed`。
3. 下载中途关闭页面再进入同一合集：按钮应变为「继续下载」，仅补未完成的分包。
4. 部分分包失败后：结束时可「继续下载」仅补失败包。
