### PR TITLE
修复 Markdown 导出混入 CSS 样式与底部操作栏

### DIFF
--- a/server/api/public/v1/download.get.ts
+++ b/server/api/public/v1/download.get.ts
@@ -1,6 +1,6 @@
-import TurndownService from 'turndown';
 import { urlIsValidMpArticle } from '#shared/utils';
 import { normalizeHtml, parseCgiDataNew } from '#shared/utils/html';
+import { createTurndownService } from '#shared/utils/markdown';
 import { USER_AGENT } from '~/config';
 import { enforceRateLimit } from '~/server/utils/rate-limit';
 
@@ -68,7 +68,7 @@ export default defineEventHandler(async event => {
         },
       });
     case 'markdown':
-      return new Response(new TurndownService().turndown(normalizeHtml(rawHtml, 'html')), {
+      return new Response(createTurndownService().turndown(normalizeHtml(rawHtml, 'html')).trim(), {
         status: 200,
         headers: {
           'Content-Type': 'text/markdown; charset=UTF-8',

--- a/shared/utils/markdown.ts
+++ b/shared/utils/markdown.ts
@@ -1,0 +1,26 @@
+import TurndownService from 'turndown';
+
+/**
+ * 创建配置好的 Turndown 实例
+ *
+ * 传入的是完整 HTML 文档，Turndown 解析时 <head> 标签本身会被丢弃，
+ * 但其中 <style>/<title> 等元素会作为节点残留，默认规则会把它们的文本
+ * 原样输出，导致整段 CSS 混入 Markdown 正文，因此需要显式移除。
+ */
+export function createTurndownService() {
+  const service = new TurndownService({
+    headingStyle: 'atx',
+    bulletListMarker: '-',
+    codeBlockStyle: 'fenced',
+  });
+
+  service.remove(['style', 'script', 'noscript', 'link', 'meta', 'title']);
+
+  // 移除底部操作栏（阅读/赞/分享/推荐/留言），其图标是内联 data URI，转换后是大段乱码
+  service.remove(node => {
+    const className = node.getAttribute?.('class') || '';
+    return className.includes('__bottom-bar__');
+  });
+
+  return service;
+}

--- a/utils/download/Exporter.ts
+++ b/utils/download/Exporter.ts
@@ -1,8 +1,8 @@
 import dayjs from 'dayjs';
 import mime from 'mime';
-import TurndownService from 'turndown';
 import { filterInvalidFilenameChars, sleep } from '#shared/utils/helpers';
 import { parseCgiDataNew } from '#shared/utils/html';
+import { createTurndownService } from '#shared/utils/markdown';
 import { renderHTMLFromCgiDataNew, renderTextFromCgiDataNew } from '#shared/utils/renderer';
 import usePreferences from '~/composables/usePreferences';
 import { getArticleByLink } from '~/store/v2/article';
@@ -408,7 +408,7 @@ export class Exporter extends BaseDownloader {
     const total = this.urls.length;
     this.emit('export:total', total);
 
-    const turndownService = new TurndownService();
+    const turndownService = createTurndownService();
 
     await this.processFileExportQueue(this.urls, async url => {
       const filename = await this.exportDirName(url);
@@ -416,7 +416,7 @@ export class Exporter extends BaseDownloader {
 
       const content = await this.getRenderedHTML(url);
       if (!content) return;
-      const markdown = turndownService.turndown(content);
+      const markdown = turndownService.turndown(content).trim();
 
       const blob = new Blob([markdown], { type: 'text/markdown' });
       await this.writeFile(filename + '.md', blob);


### PR DESCRIPTION
Markdown 导出使用未配置的 Turndown 转换 renderHTMLFromCgiDataNew() 生成的完整 HTML 文档。Turndown 解析时 <head> 标签本身被丢弃，但其中的
<style>、<title> 元素作为节点存活下来，默认规则将其文本原样输出，
导致每个 .md 文件开头混入约 2.7KB CSS 代码。

同时文件末尾会混入底部操作栏（阅读/赞/分享/推荐/留言），其图标为内联
data URI SVG，转换后约 4.1KB 无意义字符。

新增 shared/utils/markdown.ts 提供统一的 Turndown 工厂，移除
style/script/title/meta 等非正文元素，并按 class 过滤底部操作栏。
客户端导出与服务端 API 均改用该工厂（两者存在相同问题）。

实测单篇体积由约 12KB 降至约 5KB，移除内容均与正文无关。

Closes #138
Closes #167