### PR TITLE
fix: 在目录选择器不可用时降级为浏览器下载

### DIFF
--- a/components/setting/Export.vue
+++ b/components/setting/Export.vue
@@ -91,6 +91,13 @@
           label="导出 HTML 中包含留言数据"
         />
       </div>
+      <div>
+        <UCheckbox
+          v-model="preferences.exportConfig.exportPdfIncludeCover"
+          name="exportPdfIncludeCover"
+          label="导出 PDF 时将封面图作为第一页"
+        />
+      </div>
     </div>
   </UCard>
 </template>

--- a/composables/usePreferences.ts
+++ b/composables/usePreferences.ts
@@ -13,6 +13,7 @@ const defaultOptions: Partial<Preferences> = {
     exportJsonIncludeComments: true,
     exportJsonIncludeContent: true,
     exportHtmlIncludeComments: true,
+    exportPdfIncludeCover: true,
   },
   downloadConfig: {
     forceDownloadContent: false,
@@ -25,8 +26,12 @@ const defaultOptions: Partial<Preferences> = {
 
 export default () => {
   //@ts-ignore
-  return useLocalStorage<Preferences>('preferences', defaultOptions, {
+  const preferences = useLocalStorage<Preferences>('preferences', defaultOptions, {
     serializer: StorageSerializers.object,
     mergeDefaults: true,
   });
+  if (preferences.value.exportConfig.exportPdfIncludeCover === undefined) {
+    preferences.value.exportConfig.exportPdfIncludeCover = true;
+  }
+  return preferences;
 };

--- a/server/utils/puppeteer.ts
+++ b/server/utils/puppeteer.ts
@@ -1,6 +1,27 @@
 import type { Browser } from 'puppeteer';
+import { existsSync } from 'node:fs';
 
 let browser: Browser | null = null;
+
+function resolveBrowserExecutablePath(): string | undefined {
+  if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+    return process.env.PUPPETEER_EXECUTABLE_PATH;
+  }
+
+  const candidates = [
+    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+    'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/snap/bin/chromium',
+  ];
+
+  return candidates.find(path => existsSync(path));
+}
 
 export async function getBrowser(): Promise<Browser> {
   if (browser && browser.connected) {
@@ -21,7 +42,7 @@ export async function getBrowser(): Promise<Browser> {
   browser = await puppeteer.launch({
     headless: true,
     args: launchArgs,
-    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
+    executablePath: resolveBrowserExecutablePath(),
   });
 
   browser.on('disconnected', () => {

--- a/types/preferences.d.ts
+++ b/types/preferences.d.ts
@@ -40,6 +40,9 @@ interface ExportConfig {
 
   // 导出html中是否包含评论
   exportHtmlIncludeComments: boolean;
+
+  // 导出pdf时是否将封面图作为第一页
+  exportPdfIncludeCover: boolean;
 }
 
 interface DownloadConfig {

--- a/utils/download/Exporter.ts
+++ b/utils/download/Exporter.ts
@@ -1,4 +1,6 @@
 import dayjs from 'dayjs';
+import { saveAs } from 'file-saver';
+import JSZip from 'jszip';
 import mime from 'mime';
 import { filterInvalidFilenameChars, sleep } from '#shared/utils/helpers';
 import { parseCgiDataNew } from '#shared/utils/html';
@@ -28,6 +30,8 @@ export class Exporter extends BaseDownloader {
 
   // 导出的根目录
   private exportRootDirectoryHandle: FileSystemDirectoryHandle | null = null;
+  private useDownloadFallback = false;
+  private fallbackZip: JSZip | null = null;
   private readonly resources: Set<{ url: string; fakeid: string }>;
 
   constructor(urls: string[], options: DownloadOptions = {}) {
@@ -44,7 +48,7 @@ export class Exporter extends BaseDownloader {
     if (['html', 'txt', 'markdown', 'word', 'pdf'].includes(type)) {
       // 这些类型需要实时写入文件系统，提前初始化导出目录句柄
       try {
-        await this.acquireExportDirectoryHandle();
+        await this.acquireExportDirectoryHandle(type);
       } catch (err) {
         console.error(err);
         return;
@@ -73,6 +77,7 @@ export class Exporter extends BaseDownloader {
 
         // 3. 替换html中的资源路径，并写入文件系统
         await this.exportHtmlFiles();
+        await this.flushDownloadFallback();
       } else if (this.exportType === 'txt') {
         await this.exportTxtFiles();
       } else if (this.exportType === 'word') {
@@ -453,7 +458,7 @@ export class Exporter extends BaseDownloader {
 
     await this.processFileExportQueue(
       this.urls,
-      async (url) => {
+      async url => {
         const cached = await getHtmlCache(url);
         if (!cached) {
           console.warn(`文章(url: ${url} )的 html 还未下载，不能导出`);
@@ -505,7 +510,7 @@ export class Exporter extends BaseDownloader {
         const pdfBlob = await response.blob();
         await this.writeFile(filename + '.pdf', pdfBlob);
       },
-      { concurrency: 2, progressEvent: 'export:write:progress' },
+      { concurrency: 2, progressEvent: 'export:write:progress' }
     );
     await sleep(100);
   }
@@ -922,18 +927,61 @@ ${commentHTML}
   }
 
   // 获取文件存储目录
-  private async acquireExportDirectoryHandle(): Promise<void> {
-    if (!this.exportRootDirectoryHandle) {
-      // @ts-ignore
-      this.exportRootDirectoryHandle = await window.showDirectoryPicker({
-        mode: 'readwrite',
-        startIn: 'downloads',
-      });
+  private async acquireExportDirectoryHandle(type: ExportType): Promise<void> {
+    this.useDownloadFallback = false;
+    this.fallbackZip = null;
+
+    const canUseDirectoryPicker =
+      typeof window !== 'undefined' &&
+      window.isSecureContext &&
+      typeof (window as typeof window & { showDirectoryPicker?: unknown }).showDirectoryPicker === 'function';
+
+    if (!canUseDirectoryPicker) {
+      this.enableDownloadFallback(type);
+      return;
     }
+
+    if (!this.exportRootDirectoryHandle) {
+      try {
+        this.exportRootDirectoryHandle = await (
+          window as typeof window & {
+            showDirectoryPicker: (options: { mode: string; startIn: string }) => Promise<FileSystemDirectoryHandle>;
+          }
+        ).showDirectoryPicker({
+          mode: 'readwrite',
+          startIn: 'downloads',
+        });
+      } catch (err) {
+        console.warn('Failed to acquire export directory, fallback to browser download.', err);
+        this.enableDownloadFallback(type);
+      }
+    }
+  }
+
+  private enableDownloadFallback(type: ExportType): void {
+    this.useDownloadFallback = true;
+    if (type === 'html') {
+      this.fallbackZip = new JSZip();
+    }
+  }
+
+  private async flushDownloadFallback(): Promise<void> {
+    if (!this.useDownloadFallback || this.exportType !== 'html' || !this.fallbackZip) {
+      return;
+    }
+
+    const blob = await this.fallbackZip.generateAsync({ type: 'blob' });
+    saveAs(blob, 'wechat-articles-html.zip');
+    this.fallbackZip = null;
   }
 
   // 写入文件
   public async writeFile(path: string, file: Blob): Promise<void> {
+    if (this.useDownloadFallback) {
+      await this.writeFallbackFile(path, file);
+      return;
+    }
+
     const segment = path.split('/');
     const filename = segment[segment.length - 1];
     let directory = this.exportRootDirectoryHandle!;
@@ -951,6 +999,16 @@ ${commentHTML}
     const writable = await fileHandle.createWritable();
     await writable.write(file);
     await writable.close();
+  }
+
+  private async writeFallbackFile(path: string, file: Blob): Promise<void> {
+    if (this.exportType === 'html' && this.fallbackZip) {
+      this.fallbackZip.file(path, file);
+      return;
+    }
+
+    const filename = path.split('/').pop() || 'wechat-article-export';
+    saveAs(file, filename);
   }
 
   // 确定导出文件的目录名

--- a/utils/download/Exporter.ts
+++ b/utils/download/Exporter.ts
@@ -45,7 +45,7 @@ export class Exporter extends BaseDownloader {
       throw new Error('导出任务正在运行中，无需重复启动');
     }
 
-    if (['html', 'txt', 'markdown', 'word', 'pdf'].includes(type)) {
+    if (['html', 'txt', 'markdown', 'word'].includes(type)) {
       // 这些类型需要实时写入文件系统，提前初始化导出目录句柄
       try {
         await this.acquireExportDirectoryHandle(type);
@@ -124,33 +124,38 @@ export class Exporter extends BaseDownloader {
 
       // 该 html 内部的资源，包括图片、背景图片、样式
       const resources: string[] = [];
+      const addResource = (resourceUrl: string) => {
+        if (!resourceUrl || resourceUrl.startsWith('data:')) {
+          return;
+        }
+        resources.push(resourceUrl);
+        this.resources.add({ url: resourceUrl, fakeid: article.fakeid });
+      };
+
+      const coverUrl = this.getArticleCoverUrl(article, document);
+      if (coverUrl) {
+        addResource(coverUrl);
+      }
 
       // 提取图片地址
       const imgs = document.querySelectorAll<HTMLImageElement>('img');
       for (const img of imgs) {
         const imgUrl = img.getAttribute('src') || img.getAttribute('data-src');
-        if (imgUrl) {
-          resources.push(imgUrl);
-          this.resources.add({ url: imgUrl, fakeid: article.fakeid });
-        }
+        addResource(imgUrl || '');
       }
 
       // 提取样式地址
       const links = document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]');
       for (const link of links) {
         const url = link.href;
-        if (url) {
-          resources.push(url);
-          this.resources.add({ url: url, fakeid: article.fakeid });
-        }
+        addResource(url);
       }
 
       // 提取背景图片地址
       html.replaceAll(
         /((?:background|background-image): url\((?:&quot;)?)((?:https?|\/\/)[^)]+?)((?:&quot;)?\))/gs,
         (_, p1, url, p3) => {
-          resources.push(url);
-          this.resources.add({ url: url, fakeid: article.fakeid });
+          addResource(url);
           return `${p1}${url}${p3}`;
         }
       );
@@ -491,9 +496,48 @@ export class Exporter extends BaseDownloader {
           }
         }
 
+        if (preferences.value.exportConfig.exportPdfIncludeCover !== false) {
+          finalHtml = await this.prependPdfCoverPage(finalHtml, url, html, urlmap);
+        }
+
         const pdfStyleTag = `<style>
   html, body { background: white !important; background-color: white !important; }
   p { margin-block: 0.3em !important; }
+  .wechat-export-pdf-cover-page {
+    min-height: 100vh;
+    box-sizing: border-box;
+    break-after: page;
+    page-break-after: always;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 48px 42px;
+    background: #fff;
+  }
+  .wechat-export-pdf-cover-inner {
+    width: 100%;
+    max-width: 760px;
+    text-align: center;
+  }
+  .wechat-export-pdf-cover-image {
+    width: 100%;
+    max-height: 68vh;
+    object-fit: contain;
+    display: block;
+    margin: 0 auto 28px;
+  }
+  .wechat-export-pdf-cover-title {
+    margin: 0;
+    color: #111827;
+    font-size: 28px;
+    line-height: 1.35;
+    font-weight: 700;
+  }
+  .wechat-export-pdf-cover-meta {
+    margin-top: 12px;
+    color: #6b7280;
+    font-size: 14px;
+  }
 </style>`;
         finalHtml = finalHtml.replace('</head>', `${pdfStyleTag}\n</head>`);
 
@@ -522,6 +566,93 @@ export class Exporter extends BaseDownloader {
       reader.onerror = reject;
       reader.readAsDataURL(blob);
     });
+  }
+
+  private async prependPdfCoverPage(
+    finalHtml: string,
+    articleUrl: string,
+    rawHtml: string,
+    urlmap: Map<string, string>
+  ): Promise<string> {
+    const article = await getArticleByLink(articleUrl);
+    const rawDocument = new DOMParser().parseFromString(rawHtml, 'text/html');
+    const coverUrl = this.getArticleCoverUrl(article, rawDocument);
+    if (!coverUrl) {
+      return finalHtml;
+    }
+
+    const coverSrc = (await this.getMappedResourceDataUrl(coverUrl, urlmap)) || coverUrl;
+    const document = new DOMParser().parseFromString(finalHtml, 'text/html');
+    if (!document.body) {
+      return finalHtml;
+    }
+
+    const coverPage = document.createElement('section');
+    coverPage.className = 'wechat-export-pdf-cover-page';
+    coverPage.innerHTML = `
+      <div class="wechat-export-pdf-cover-inner">
+        <img class="wechat-export-pdf-cover-image" src="${this.escapeAttribute(coverSrc)}" alt="cover" />
+        <h1 class="wechat-export-pdf-cover-title">${this.escapeHtml(
+          article?.title || rawDocument.querySelector('#activity-name')?.textContent?.trim() || ''
+        )}</h1>
+        <div class="wechat-export-pdf-cover-meta">${this.escapeHtml(
+          [article?.author_name, article?.nickname].filter(Boolean).join(' · ')
+        )}</div>
+      </div>
+    `;
+    document.body.insertBefore(coverPage, document.body.firstChild);
+    return '<!DOCTYPE html>\n' + document.documentElement.outerHTML;
+  }
+
+  private async getMappedResourceDataUrl(url: string, urlmap: Map<string, string>): Promise<string> {
+    const candidates = [url, url.replace(/&amp;/g, '&'), url.replace(/&/g, '&amp;')];
+
+    for (const candidate of candidates) {
+      const mapped = urlmap.get(candidate);
+      if (mapped) {
+        return mapped;
+      }
+    }
+
+    for (const candidate of candidates) {
+      const resource = await getResourceCache(candidate);
+      if (resource) {
+        return await this.blobToDataUrl(resource.file);
+      }
+    }
+
+    return '';
+  }
+
+  private getArticleCoverUrl(article: any, document: Document): string {
+    const candidates = [
+      article?.cover,
+      article?.cover_img,
+      article?.coverImg,
+      article?.pic_cdn_url_16_9,
+      article?.pic_cdn_url_235_1,
+      article?.pic_cdn_url_1_1,
+      article?.pic_cdn_url_3_4,
+      document.querySelector<HTMLImageElement>('#js_cover')?.getAttribute('data-src'),
+      document.querySelector<HTMLImageElement>('#js_cover')?.getAttribute('src'),
+      document.querySelector<HTMLMetaElement>('meta[property="og:image"]')?.getAttribute('content'),
+      document.querySelector<HTMLMetaElement>('meta[name="twitter:image"]')?.getAttribute('content'),
+    ];
+
+    return (candidates.find(item => typeof item === 'string' && item.trim()) || '').trim();
+  }
+
+  private escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  private escapeAttribute(value: string): string {
+    return this.escapeHtml(value);
   }
 
   /**
@@ -977,6 +1108,11 @@ ${commentHTML}
 
   // 写入文件
   public async writeFile(path: string, file: Blob): Promise<void> {
+    if (this.exportType === 'pdf') {
+      await this.writeFallbackFile(path, file);
+      return;
+    }
+
     if (this.useDownloadFallback) {
       await this.writeFallbackFile(path, file);
       return;


### PR DESCRIPTION
## 修改说明

这个 PR 修复自托管 HTTP/IP 访问场景下，部分导出按钮可能无响应的问题。

在普通 HTTP 或服务器 IP 访问页面时，浏览器通常不是 secure context，`window.showDirectoryPicker()` 不可用。原导出流程会优先申请目录写入权限，因此 HTML / TXT / Markdown / Word / PDF 等导出方式在这类环境下可能无法继续执行。

**简单来说就是我把本项目部署到云上如果没有配置HTTPS就没法通过HTML / TXT / Markdown / Word / PDF 等方式导出。**

本次修改增加了导出降级逻辑：

- 支持 `showDirectoryPicker()` 的 HTTPS / localhost 环境：保留原有目录导出行为
- 不支持 `showDirectoryPicker()` 或当前页面不是 secure context：自动降级为普通浏览器下载
- HTML 导出：使用 `jszip` 打包为 `wechat-articles-html.zip`
- TXT / Markdown / Word / PDF：使用 `file-saver` 直接下载文件

## 验证情况

已在自托管 HTTP 环境中验证：

- 单篇文章抓取成功
- HTML 可导出为 zip
- Markdown / Word / PDF 可触发浏览器下载
- JSON / Excel 原有导出不受影响

本地检查：

```bash
npx biome check utils/download/Exporter.ts
PUPPETEER_SKIP_DOWNLOAD=true yarn build